### PR TITLE
Make behavior of backspace optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ Then pressing "Backspace" will produce:
 - [ ] two|apple
 ```
 
+If you want to disable this behavior, add this to your `init.el`:
+
+```elisp
+(setq org-autolist-enable-delete t)
+```
+
 ## Feedback
 
 If you find a bug, or have a suggestion for an improvement, then feel free to submit an issue or pull request!

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ When editing a list item, pressing "Return" will insert a new list item automati
 
 ## Installation
 
-The recommended way to install  org-autolist is via `package.el`.
+The recommended way to install  org-autolist  via `package.el`.
 
 ### MELPA Stable
 

--- a/org-autolist.el
+++ b/org-autolist.el
@@ -42,6 +42,11 @@
 ;; To enable it whenever you open an org file, add this to your init.el:
 ;;
 ;;   (add-hook 'org-mode-hook (lambda () (org-autolist-mode)))
+;;
+;; To disable backspace deleting the whole list item, add this:
+;;
+;;   (setq org-autolist-enable-delete t)
+;;
 
 ;;; Code:
 (require 'org)

--- a/org-autolist.el
+++ b/org-autolist.el
@@ -47,6 +47,9 @@
 (require 'org)
 (require 'org-element)
 
+(defvar org-autolist-enable-delete t
+  "Non-nil to allow the Backspace key to automatically delete list prefixes.")
+
 (defun org-autolist-beginning-of-item-after-bullet ()
   "Returns the position before the first character after the
 bullet of the current list item.
@@ -137,7 +140,8 @@ key to automatically delete list prefixes.
   move the current list item up one line."
   ;; We should only invoke our custom logic if we're at the beginning of a list
   ;; item right after the bullet character.
-  (if (and (org-at-item-p)
+  (if (and org-autolist-enable-delete
+           (org-at-item-p)
            (<= (point) (org-autolist-beginning-of-item-after-bullet)))
       ;; If the previous line is empty, then just delete the previous line (i.e.,
       ;; shift the list up by one line).


### PR DESCRIPTION
In 80% of the cases, I'm personally a fan of the default behavior. But when I want to make a checklist `- [ ] foo` into a regular list item, `- foo`, the magic behavior always gets in the way. 

Deleting a whole line is super simple, though, so I figured: try disabling the backspace magic.

Not happy with the name of the variable, but not sure what else to call it.

This PR adds an option to disable the backspace key's behavior:

    (setq org-autolist-enable-delete nil)
