### PR TITLE
Add customization group for org-autolist

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Then pressing "Backspace" will produce:
 If you want to disable this behavior, add this to your `init.el`:
 
 ```elisp
-(setq org-autolist-enable-delete t)
+(setq org-autolist-enable-delete nil)
 ```
 
 ## Feedback

--- a/org-autolist.el
+++ b/org-autolist.el
@@ -83,8 +83,7 @@ Set to nil to disable automatic removal."
 ;;; Internal Functions
 
 (defun org-autolist-beginning-of-item-after-bullet ()
-  "Returns the position before the first character after the
-bullet of the current list item.
+  "Return the position after the bullet of the current list item.
 
 This function uses the same logic as `org-beginning-of-line' when
 `org-special-ctrl-a/e' is enabled"
@@ -104,7 +103,7 @@ This function uses the same logic as `org-beginning-of-line' when
   (org-list-at-regexp-after-bullet-p "\\(\\s-*\\)::\\(\\s-*$\\)"))
 
 (defadvice org-return (around org-autolist-return)
-  "Wraps the org-return function to allow the Return key to
+  "Wraps the `org-return' function to allow the Return key to \
 automatically insert new list items.
 
 - Pressing Return at the end of a list item inserts a new list item.
@@ -163,8 +162,9 @@ automatically insert new list items.
       ad-do-it)))
 
 (defadvice org-delete-backward-char (around org-autolist-delete-backward-char)
-  "Wraps the org-delete-backward-char function to allow the Backspace
-key to automatically delete list prefixes.
+  "Wraps the `org-delete-backward-char' function to allow \
+`\\<org-mode-map>\\[delete-backward-char]' to automatically delete \
+list prefixes if `org-autolist-enable-delete' is t.
 
 - Pressing backspace at the beginning of a list item deletes it and
   moves the cursor to the previous line.
@@ -215,8 +215,8 @@ key to automatically delete list prefixes.
 
 ;;;###autoload
 (define-minor-mode org-autolist-mode
-  "Enables improved list management in org-mode."
   nil " Autolist" nil
+  "Enables improved list management in `org-mode'."
   (cond
    ;; If enabling org-autolist-mode, then add our advice functions.
    (org-autolist-mode

--- a/org-autolist.el
+++ b/org-autolist.el
@@ -45,7 +45,7 @@
 ;;
 ;; To disable backspace deleting the whole list item, add this:
 ;;
-;;   (setq org-autolist-enable-delete t)
+;;   (setq org-autolist-enable-delete nil)
 ;;
 
 ;;; Code:

--- a/org-autolist.el
+++ b/org-autolist.el
@@ -49,11 +49,38 @@
 ;;
 
 ;;; Code:
+
+
+
 (require 'org)
 (require 'org-element)
 
-(defvar org-autolist-enable-delete t
-  "Non-nil to allow the Backspace key to automatically delete list prefixes.")
+(defgroup org-autolist ()
+  "Options for `org-autolist'."
+  :group 'org
+  :prefix "org-autolist-"
+  :tag "Org Autolist")
+
+
+
+;;; Customization variables
+
+(defcustom org-autolist-enable-delete t
+  "Controls auto-deletion of list prefixes when typing e.g. \
+`\\<org-mode-map>\\[delete-backward-char]'.
+
+By default, hitting backspace after a list item prefix will not
+just delete the character, but the whole prefix. In case of
+checkboxes like “- [ ] this”, backward deletion before “this”
+will remove the checkbox and the dash.
+
+Set to nil to disable automatic removal."
+  :type 'boolean
+  :group 'org-autolist)
+
+
+
+;;; Internal Functions
 
 (defun org-autolist-beginning-of-item-after-bullet ()
   "Returns the position before the first character after the

--- a/org-autolist.el
+++ b/org-autolist.el
@@ -215,8 +215,9 @@ list prefixes if `org-autolist-enable-delete' is t.
 
 ;;;###autoload
 (define-minor-mode org-autolist-mode
-  nil " Autolist" nil
   "Enables improved list management in `org-mode'."
+  :lighter " Autolist"
+  :keymap nil
   (cond
    ;; If enabling org-autolist-mode, then add our advice functions.
    (org-autolist-mode


### PR DESCRIPTION
I forgot to push a commit that fixed the README and docstring in my last PR (inverted logic :))

Figured I might as well change this into a customizable variable instead so users can toggle this from the widget interface.

![Screen Shot 2021-12-22 at 08 38 23](https://user-images.githubusercontent.com/59080/147055627-6e76635d-1e80-424e-b35e-81ed17918357.png)

