### PR TITLE
Avoid bypassing org-return when using RET on reference links

### DIFF
--- a/org-autolist.el
+++ b/org-autolist.el
@@ -125,7 +125,9 @@ automatically insert new list items.
     (if (and is-listitem
           (not
             (and org-return-follows-link
-              (eq 'org-link (get-text-property (point) 'face)))))
+                 (member (car (org-element-context))
+                         '( link citation footnote-reference citation-reference
+                            timestamp)))))
       ;; If we're at the beginning of an empty list item, then try to outdent
       ;; it. If it can't be outdented (b/c it's already at the outermost
       ;; indentation level), then delete it.


### PR DESCRIPTION
## Issue
When hitting return on an inline reference link or a timestamp like these:
```org-mode
- This is a citation: [cite:@karlsson22_numer_study_heat_trans_flow]
- This is a timestamp: [2022-05-29 Sun]
```
org-autolist bypasses org-return, resulting in this:
```org-mode
- This is a citation: [cite:@karlsson22_num
- er_study_heat_trans_flow]
- This is a timestamp: [2022-0
- 5-29 Sun]
```
Only org links like this:
```org-mode
- This is a link: [[file:path/to/image.png]]
```
are properly opened.

## Solution
This PR checks for the thing at point, to ensure hitting return will properly follow any kind of links (reference, citation, timestamps, ...).