### PR TITLE
Revert "Avoid bypassing org-return when using RET on reference links"

### DIFF
--- a/org-autolist.el
+++ b/org-autolist.el
@@ -125,9 +125,7 @@ automatically insert new list items.
     (if (and is-listitem
           (not
             (and org-return-follows-link
-                 (member (car (org-element-context))
-                         '( link citation footnote-reference citation-reference
-                            timestamp)))))
+              (eq 'org-link (get-text-property (point) 'face)))))
       ;; If we're at the beginning of an empty list item, then try to outdent
       ;; it. If it can't be outdented (b/c it's already at the outermost
       ;; indentation level), then delete it.

--- a/org-autolist.el
+++ b/org-autolist.el
@@ -5,7 +5,7 @@
 ;; Author: Calvin Young
 ;; Keywords: lists, checklists, org-mode
 ;; Homepage: https://github.com/calvinwyoung/org-autolist
-;; Version: 0.15
+;; Version: 0.16
 
 ;; This file is not part of GNU Emacs.
 


### PR DESCRIPTION
Reverts calvinwyoung/org-autolist#19

Note: https://github.com/calvinwyoung/org-autolist/pull/19#commitcomment-74901559