### PR TITLE
Use the org-element API to access the parsed information

### DIFF
--- a/org-autolist.el
+++ b/org-autolist.el
@@ -116,48 +116,48 @@ automatically insert new list items.
   ;; `org-return-follows-link` is enabled -- in this case, we should just let
   ;; org mode default to following the link.
   (let* ((el (org-element-at-point))
-          (parent (plist-get (cadr el) :parent))
-          ;; handle hard-wrapped list-items
-          (is-listitem (or (org-at-item-p)
-                         (and (eq 'paragraph (car el))
-                           (eq 'item (car parent)))))
-          (is-checkbox (plist-get (cadr parent) :checkbox)))
+         (parent (plist-get (cadr el) :parent))
+         ;; handle hard-wrapped list-items
+         (is-listitem (or (org-at-item-p)
+                          (and (eq 'paragraph (car el))
+                               (eq 'item (car parent)))))
+         (is-checkbox (plist-get (cadr parent) :checkbox)))
     (if (and is-listitem
-          (not
-            (and org-return-follows-link
-              (eq 'org-link (get-text-property (point) 'face)))))
-      ;; If we're at the beginning of an empty list item, then try to outdent
-      ;; it. If it can't be outdented (b/c it's already at the outermost
-      ;; indentation level), then delete it.
-      (if (and (eolp)
-            ;; need to recheck in case we're at a hard-wrapped list-item
-            (org-at-item-p)
-            (<= (point) (org-autolist-beginning-of-item-after-bullet)))
-        (condition-case nil
-          (call-interactively 'org-outdent-item)
-          ('error (delete-region (line-beginning-position)
-                    (line-end-position))))
+             (not
+              (and org-return-follows-link
+                   (eq 'org-link (get-text-property (point) 'face)))))
+        ;; If we're at the beginning of an empty list item, then try to outdent
+        ;; it. If it can't be outdented (b/c it's already at the outermost
+        ;; indentation level), then delete it.
+        (if (and (eolp)
+                 ;; need to recheck in case we're at a hard-wrapped list-item
+                 (org-at-item-p)
+                 (<= (point) (org-autolist-beginning-of-item-after-bullet)))
+            (condition-case nil
+                (call-interactively 'org-outdent-item)
+              ('error (delete-region (line-beginning-position)
+                                     (line-end-position))))
 
-        ;; Now we can insert a new list item. The logic here is a little tricky
-        ;; depending on the type of list we're dealing with.
-        (cond
-          ;; If we're on a checkbox item, then insert a new checkbox
-          (is-checkbox
+          ;; Now we can insert a new list item. The logic here is a little tricky
+          ;; depending on the type of list we're dealing with.
+          (cond
+           ;; If we're on a checkbox item, then insert a new checkbox
+           (is-checkbox
             (org-insert-todo-heading nil))
 
-          ;; If we're in a description list, and the point is between the start
-          ;; of the list (after the bullet) and the end of the list, then we
-          ;; should simply insert a newline. This is a bit weird and inconsistent
-          ;; w/ the UX for other list types, but we do this b/c `org-meta-return'
-          ;; has some very strange behavior when executed in the middle of a
-          ;; description list.
-          ((and (org-at-item-description-p)
-             (> (point) (org-autolist-beginning-of-item-after-bullet))
-             (< (point) (line-end-position)))
+           ;; If we're in a description list, and the point is between the start
+           ;; of the list (after the bullet) and the end of the list, then we
+           ;; should simply insert a newline. This is a bit weird and inconsistent
+           ;; w/ the UX for other list types, but we do this b/c `org-meta-return'
+           ;; has some very strange behavior when executed in the middle of a
+           ;; description list.
+           ((and (org-at-item-description-p)
+                 (> (point) (org-autolist-beginning-of-item-after-bullet))
+                 (< (point) (line-end-position)))
             (newline))
 
-          ;; Otherwise just let org-mode figure it out it.
-          (t
+           ;; Otherwise just let org-mode figure it out it.
+           (t
             (org-meta-return))))
       ad-do-it)))
 

--- a/org-autolist.el
+++ b/org-autolist.el
@@ -116,12 +116,12 @@ automatically insert new list items.
   ;; `org-return-follows-link` is enabled -- in this case, we should just let
   ;; org mode default to following the link.
   (let* ((el (org-element-at-point))
-         (parent (plist-get (cadr el) :parent))
+         (parent (org-element-parent el))
          ;; handle hard-wrapped list-items
          (is-listitem (or (org-at-item-p)
-                          (and (eq 'paragraph (car el))
-                               (eq 'item (car parent)))))
-         (is-checkbox (plist-get (cadr parent) :checkbox)))
+                          (and (eq 'paragraph (org-element-type el))
+                               (eq 'item (org-element-type parent)))))
+         (is-checkbox (org-element-property :checkbox parent)))
     (if (and is-listitem
              (not
               (and org-return-follows-link


### PR DESCRIPTION
The data returned by `org-element-at-point` has been changed, and the previous implementation of this package no longer works with the latest version of Org. It's safer to use the public functions from `org-element.el`, which I have done in this PR. 

Also, the original indentation of the source code seemed to be corrupted, or at least an unusual one I have never seen. I applied the default space indentation before I modify the function.